### PR TITLE
Elo Object & Tournament Object Population

### DIFF
--- a/lm_tournament_eval/__main__.py
+++ b/lm_tournament_eval/__main__.py
@@ -162,7 +162,8 @@ def run_tournament():
                               task_names=task_names,
                               batch_size=args.batch_size,
                               device=args.device,
-                              limit=args.limit
+                              limit=args.limit,
+                              match_size=args.match_size
                              )
 
         #create tournament

--- a/lm_tournament_eval/__main__.py
+++ b/lm_tournament_eval/__main__.py
@@ -10,6 +10,7 @@ from lm_tournament_eval.api.tournament import TournamentConfig, Tournament
 from lm_tournament_eval.api.offline_tournament import OfflineTournamentConfig, OfflineTournament
 from lm_tournament_eval.api.task import TaskConfig
 from lm_tournament_eval.tasks import TaskManager
+from lm_tournament_eval.api.elo import ELO
 
 from lm_tournament_eval.tournament_evaluator import tournament_evaluate
 
@@ -182,7 +183,9 @@ def run_tournament():
         )
 
         newline = '\n'
-        print(f"{results0}{newline*10}{results1}")
+        # print(f"{results0}{newline*10}{results1}")
+        elo = ELO()
+        elo.elo_update(results0, results1, task_names)
 
     # save tournament results to disk.
 

--- a/lm_tournament_eval/__main__.py
+++ b/lm_tournament_eval/__main__.py
@@ -155,8 +155,10 @@ def run_tournament():
         # validate tournament parameters.
         cfg = TournamentConfig(name=args.tournament_name,
                               rounds=args.num_rounds,
-                              model0_name = args.model0,
-                              model1_name = args.model1,
+                              model0_name=args.model0,
+                              model0_args=args.model0_args,
+                              model1_name=args.model1,
+                              model1_args=args.model1_args,
                               task_names=task_names,
                               batch_size=args.batch_size,
                               device=args.device,

--- a/lm_tournament_eval/__main__.py
+++ b/lm_tournament_eval/__main__.py
@@ -10,10 +10,6 @@ from lm_tournament_eval.api.tournament import TournamentConfig, Tournament
 from lm_tournament_eval.api.offline_tournament import OfflineTournamentConfig, OfflineTournament
 from lm_tournament_eval.api.task import TaskConfig
 from lm_tournament_eval.tasks import TaskManager
-from lm_tournament_eval.api.elo import ELO
-
-from lm_tournament_eval.tournament_evaluator import tournament_evaluate
-
 from lm_tournament_eval.evaluator_utils import request_caching_arg_to_dict
 
 def setup_parser() -> argparse.ArgumentParser:
@@ -157,35 +153,24 @@ def run_tournament():
         result = tournament.run_tournament()    
     else:
         # validate tournament parameters.
-        #cfg = TournamentConfig(name=args.tournament_name,
-        #                       rounds=args.num_rounds,
-        #                       model0_name = args.model0,
-        #                       model1_name = args.model1,
-        #                       task_name=args.tasks
-        #                      )
+        cfg = TournamentConfig(name=args.tournament_name,
+                              rounds=args.num_rounds,
+                              model0_name = args.model0,
+                              model1_name = args.model1,
+                              task_names=task_names,
+                              batch_size=args.batch_size,
+                              device=args.device,
+                              limit=args.limit
+                             )
 
-        # create tournament
-        #tournament = Tournament(cfg)
+        #create tournament
+        tournament = Tournament(cfg, task_names, task_manager, args.verbosity)
 
         #logging.info(f"Running tournament {cfg}")
+        tournament.run_tournament()
 
-        results0, results1 = tournament_evaluate(
-            model_type="hf",
-            model0=args.model0,
-            model1=args.model1,
-            model0_args=args.model0_args,
-            model1_args=args.model1_args,
-            tasks=task_names,
-            task_manager=task_manager,
-            limit=args.limit,
-            batch_size=args.batch_size,
-            device=args.device
-        )
-
-        newline = '\n'
+        #newline = '\n'
         # print(f"{results0}{newline*10}{results1}")
-        elo = ELO()
-        elo.elo_update(results0, results1, task_names)
 
     # save tournament results to disk.
 

--- a/lm_tournament_eval/api/elo.py
+++ b/lm_tournament_eval/api/elo.py
@@ -11,68 +11,67 @@ class ELO:
         self.score_1 = 1200
         self.k = 16
 
-    def online_elo_update(self, results0 : dict, results1 : dict, task_names : List):
+    def online_elo_update(self, results0 : dict, results1 : dict, task_names : List, match_size : int):
         # self.match_result_list.model0_old_elo = self.score_0
         # self.match_result_list.model1_old_elo = self.score_1
-        print(f"score_0, 1 {self.score_0}, {self.score_1}")
+        print(f"match 0 : score_0, 1 {self.score_0}, {self.score_1}")
         print("----------------------------")
         #create list of len(num_samples) of correct/incorrect answers from results
-        answers0 = [] 
+        answers0 = {}
+        answers1 = {}
         for task_name in task_names:
-            for result in results0["samples"][task_name]:
-                nll = [response[0][0] for response in result["resps"]]
-                prediction = argmax(nll)
-                if prediction == result["target"]:
-                    answers0.append(1)
-                else:
-                    answers0.append(0)
+            answers0[task_name] = []
+            answers1[task_name] = []
+            for i in range(0, len(results0["samples"][task_name]), match_size):
+                for result0, result1 in zip(results0["samples"][task_name][i:i+match_size], results1["samples"][task_name][i:i+match_size]):
+                    nll0 = [response[0][0] for response in result0["resps"]]
+                    nll1 = [response[0][0] for response in result1["resps"]]
+                    prediction0 = argmax(nll0)
+                    prediction1 = argmax(nll1)
+                    if prediction0 == result0["target"]:
+                        answers0[task_name].append(1)
+                    else:
+                        answers0[task_name].append(0)
+                    if prediction1 == result1["target"]:
+                        answers1[task_name].append(1)
+                    else:
+                        answers1[task_name].append(0)
 
-        answers1 = [] 
-        for task_name in task_names:
-            for result in results1["samples"][task_name]:
-                nll = [response[0] for response in result["resps"]]
-                prediction = argmax(nll)
-                if prediction == result["target"]:
-                    answers1.append(1)
-                else:
-                    answers1.append(0)
+                # calculate the wins, losses, and draws
+                as_0 = []
+                as_1 = []
 
-        # calculate the wins, losses, and draws
-        as_0 = []
-        as_1 = []
+                for i in range(len(answers0[task_name])):
+                    # draw
+                    if answers0[task_name][i] == answers1[task_name][i]:
+                        as_0.append(0)
+                        as_1.append(0)
+                    # model 1 won 
+                    elif answers0[task_name][i] > answers1[task_name][i]:
+                        as_0.append(1)
+                    # model 2 won
+                    elif answers0[task_name][i] < answers1[task_name][i]:
+                        as_1.append(1)
 
-        for i in range(len(answers0)):
-            # draw
-            if answers0[i] == answers1[i]:
-                as_0.append(0)
-                as_1.append(0)
-            # model 1 won 
-            elif answers0[i] > answers1[i]:
-                as_0.append(1)
-            # model 2 won
-            elif answers0[i] < answers1[i]:
-                as_1.append(1)
-        
+                expected_score_0 = 1/(1+10**((self.score_0-self.score_1)/400))
+                expected_score_1 = 1/(1+10**((self.score_1-self.score_0)/400))
 
-        expected_score_0 = 1/(1+10**((self.score_0-self.score_1)/400))
-        expected_score_1 = 1/(1+10**((self.score_1-self.score_0)/400))
-        
-        # update Elo
-        if sum(as_0) > sum(as_1):
-            self.score_0 = self.score_0 + self.k*(1 - expected_score_0)
-            self.score_1 = self.score_1 + self.k*(0 - expected_score_1)
-        elif sum(as_1) > sum(as_0):
-            self.score_0 = self.score_0 + self.k*(0 - expected_score_0)
-            self.score_1 = self.score_1 + self.k*(1 - expected_score_1)
-        elif sum(as_0) == sum(as_1):
-            self.score_0 = self.score_0 + self.k*(0.5 - expected_score_0)
-            self.score_1 = self.score_1 + self.k*(0.5 - expected_score_1)           
-        print(f"score_0, 1 {self.score_0}, {self.score_1}")
-        print("----------------------------")
-        # self.match_result_list[n].model0_new_elo = self.score_0
-        # self.match_result_list[n].model1_new_elo = self.score_1
+                # update Elo
+                if sum(as_0) > sum(as_1):
+                    self.score_0 = self.score_0 + self.k*(1 - expected_score_0)
+                    self.score_1 = self.score_1 + self.k*(0 - expected_score_1)
+                elif sum(as_1) > sum(as_0):
+                    self.score_0 = self.score_0 + self.k*(0 - expected_score_0)
+                    self.score_1 = self.score_1 + self.k*(1 - expected_score_1)
+                elif sum(as_0) == sum(as_1):
+                    self.score_0 = self.score_0 + self.k*(0.5 - expected_score_0)
+                    self.score_1 = self.score_1 + self.k*(0.5 - expected_score_1)           
+                print(f"match {(i+1)/match_size} : score_0, 1 {self.score_0}, {self.score_1}")
+                print("----------------------------")
+                # self.match_result_list[n].model0_new_elo = self.score_0
+                # self.match_result_list[n].model1_new_elo = self.score_1
 
-    def offline_elo_update(results0, results1, task_names, task_indices):
+    def offline_elo_update(self, results0, results1, task_names, task_indices):
         # run match
         # sample indices
         # calculate the wins, losses, and draws

--- a/lm_tournament_eval/api/elo.py
+++ b/lm_tournament_eval/api/elo.py
@@ -20,7 +20,7 @@ class ELO:
         answers0 = [] 
         for task_name in task_names:
             for result in results0["samples"][task_name]:
-                nll = [response[0] for response in result["resps"]]
+                nll = [response[0][0] for response in result["resps"]]
                 prediction = argmax(nll)
                 if prediction == result["target"]:
                     answers0.append(1)

--- a/lm_tournament_eval/api/elo.py
+++ b/lm_tournament_eval/api/elo.py
@@ -1,0 +1,78 @@
+from .match import MatchResult, Match
+from typing import List
+
+def argmax(iterable):
+    return max(enumerate(iterable), key=lambda x: x[1])[0]
+
+class ELO:
+    def __init__(self):
+        # set the initial scores
+        self.score_0 = 1200
+        self.score_1 = 1200
+        self.k = 16
+        self.match_result_list = [MatchResult(model0_old_elo=self.score_0,
+                                              model1_old_elo=self.score_1,
+                                              model0_new_elo=self.score_0,
+                                              model1_new_elo=self.score_1)]
+
+
+    def elo_update(self, results0 : dict, results1 : dict, task_names : List):
+        # self.match_result_list.model0_old_elo = self.score_0
+        # self.match_result_list.model1_old_elo = self.score_1
+        print(f"score_0, 1 {self.score_0}, {self.score_1}")
+        print("----------------------------")
+        #create list of len(num_samples) of correct/incorrect answers from results
+        answers0 = [] 
+        for task_name in task_names:
+            for result in results0["samples"][task_name]:
+                nll = [response[0] for response in result["resps"]]
+                prediction = argmax(nll)
+                if prediction == result["target"]:
+                    answers0.append(1)
+                else:
+                    answers0.append(0)
+
+        answers1 = [] 
+        for task_name in task_names:
+            for result in results1["samples"][task_name]:
+                nll = [response[0] for response in result["resps"]]
+                prediction = argmax(nll)
+                if prediction == result["target"]:
+                    answers1.append(1)
+                else:
+                    answers1.append(0)
+
+        # calculate the wins, losses, and draws
+        as_0 = []
+        as_1 = []
+
+        for i in range(len(answers0)):
+            # draw
+            if answers0[i] == answers1[i]:
+                as_0.append(0)
+                as_1.append(0)
+            # model 1 won 
+            elif answers0[i] > answers1[i]:
+                as_0.append(1)
+            # model 2 won
+            elif answers0[i] < answers1[i]:
+                as_1.append(1)
+        
+
+        expected_score_0 = 1/(1+10**((self.score_0-self.score_1)/400))
+        expected_score_1 = 1/(1+10**((self.score_1-self.score_0)/400))
+        
+        # update Elo
+        if sum(as_0) > sum(as_1):
+            self.score_0 = self.score_0 + self.k*(1 - expected_score_0)
+            self.score_1 = self.score_1 + self.k*(0 - expected_score_1)
+        elif sum(as_1) > sum(as_0):
+            self.score_0 = self.score_0 + self.k*(0 - expected_score_0)
+            self.score_1 = self.score_1 + self.k*(1 - expected_score_1)
+        elif sum(as_0) == sum(as_1):
+            self.score_0 = self.score_0 + self.k*(0.5 - expected_score_0)
+            self.score_1 = self.score_1 + self.k*(0.5 - expected_score_1)           
+        print(f"score_0, 1 {self.score_0}, {self.score_1}")
+        print("----------------------------")
+        # self.match_result_list[n].model0_new_elo = self.score_0
+        # self.match_result_list[n].model1_new_elo = self.score_1

--- a/lm_tournament_eval/api/elo.py
+++ b/lm_tournament_eval/api/elo.py
@@ -10,13 +10,8 @@ class ELO:
         self.score_0 = 1200
         self.score_1 = 1200
         self.k = 16
-        self.match_result_list = [MatchResult(model0_old_elo=self.score_0,
-                                              model1_old_elo=self.score_1,
-                                              model0_new_elo=self.score_0,
-                                              model1_new_elo=self.score_1)]
 
-
-    def elo_update(self, results0 : dict, results1 : dict, task_names : List):
+    def online_elo_update(self, results0 : dict, results1 : dict, task_names : List):
         # self.match_result_list.model0_old_elo = self.score_0
         # self.match_result_list.model1_old_elo = self.score_1
         print(f"score_0, 1 {self.score_0}, {self.score_1}")
@@ -76,3 +71,36 @@ class ELO:
         print("----------------------------")
         # self.match_result_list[n].model0_new_elo = self.score_0
         # self.match_result_list[n].model1_new_elo = self.score_1
+
+    def offline_elo_update(results0, results1, task_names, task_indices):
+        # run match
+        # sample indices
+        # calculate the wins, losses, and draws
+        as_1 = []
+        as_2 = []
+        for i in task_indices:
+            # draw
+            if results0[i]['acc'] == results1[i]['acc']:
+                as_1.append(0)
+                as_2.append(0)
+            # model 1 won 
+            elif results0[i]['acc'] > results1[i]['acc']:
+                as_1.append(1)
+            # model 2 won
+            elif results0[i]['acc'] < results1[i]['acc']:
+                as_2.append(1)
+        expected_score_0 = 1/(1+10**((self.score_0-self.score_1)/400))
+        expected_score_1 = 1/(1+10**((self.score_1-self.score_0)/400))
+        
+        # update Elo
+        if sum(as_1) > sum(as_2):
+            self.score_0 = self.score_0 + self.k*(1 - expected_score_0)
+            self.score_1 = self.score_1 + self.k*(0 - expected_score_1)
+        elif sum(as_2) > sum(as_1):
+            self.score_0 = self.score_0 + self.k*(0 - expected_score_0)
+            self.score_1 = self.score_1 + self.k*(1 - expected_score_1)
+        elif sum(as_1) == sum(as_2):
+            self.score_0 = self.score_0 + self.k*(0.5 - expected_score_0)
+            self.score_1 = self.score_1 + self.k*(0.5 - expected_score_1)           
+        print(f"score_0, 1 {self.score_0}, {self.score_1}")
+        print("----------------------------")

--- a/lm_tournament_eval/api/elo.py
+++ b/lm_tournament_eval/api/elo.py
@@ -1,5 +1,5 @@
 from .match import MatchResult, Match
-from typing import List
+from typing import List, Dict
 
 def argmax(iterable):
     return max(enumerate(iterable), key=lambda x: x[1])[0]
@@ -11,15 +11,16 @@ class ELO:
         self.score_1 = 1200
         self.k = 16
 
-    def online_elo_update(self, results0 : dict, results1 : dict, task_names : List, match_size : int):
-        # self.match_result_list.model0_old_elo = self.score_0
-        # self.match_result_list.model1_old_elo = self.score_1
+    def online_elo_update(self, results0 : Dict, results1 : Dict, task_names : List, match_size : int, match_results : Dict):
+        index = 0
         print(f"match 0 : score_0, 1 {self.score_0}, {self.score_1}")
         print("----------------------------")
         #create list of len(num_samples) of correct/incorrect answers from results
         answers0 = {}
         answers1 = {}
         for task_name in task_names:
+            match_results[task_name][0].model0_old_elo = self.score_0
+            match_results[task_name][0].model1_old_elo = self.score_1
             answers0[task_name] = []
             answers1[task_name] = []
             for i in range(0, len(results0["samples"][task_name]), match_size):
@@ -66,10 +67,11 @@ class ELO:
                 elif sum(as_0) == sum(as_1):
                     self.score_0 = self.score_0 + self.k*(0.5 - expected_score_0)
                     self.score_1 = self.score_1 + self.k*(0.5 - expected_score_1)           
-                print(f"match {(i+1)/match_size} : score_0, 1 {self.score_0}, {self.score_1}")
+                match_results[task_name][index].model0_old_elo = self.score_0
+                match_results[task_name][index].model1_old_elo = self.score_1
+                index += 1
+                print(f"match {index} : score_0, 1 {self.score_0}, {self.score_1}")
                 print("----------------------------")
-                # self.match_result_list[n].model0_new_elo = self.score_0
-                # self.match_result_list[n].model1_new_elo = self.score_1
 
     def offline_elo_update(self, results0, results1, task_names, task_indices):
         # run match

--- a/lm_tournament_eval/api/match.py
+++ b/lm_tournament_eval/api/match.py
@@ -10,23 +10,23 @@ class MatchResult:
     """
     A record of the results of a match between two models.
     """
-    model0_name: str
-    model1_name: str
+    # model0_name: str
+    # model1_name: str
     model0_old_elo: float
     model1_old_elo: float
     model0_new_elo: float
     model1_new_elo: float
-    task_config : TaskConfig
+    # task_config : TaskConfig
 
-    task_indices : List[int] = field(
-        metadata={"doc" : "Indices from the task that make up the match"},
-        default_factory=list
-    )
+    # task_indices : List[int] = field(
+    #     metadata={"doc" : "Indices from the task that make up the match"},
+    #     default_factory=list
+    # )
 
-    match_points : List[int] = field(
-       metadata={"doc" : "Array of winner for each 'point' - model 0 or model 1."},
-       default_factory=list
-    )
+    # match_points : List[int] = field(
+    #    metadata={"doc" : "Array of winner for each 'point' - model 0 or model 1."},
+    #    default_factory=list
+    # )
 
 class Match:
     def __init__(self):

--- a/lm_tournament_eval/api/match.py
+++ b/lm_tournament_eval/api/match.py
@@ -10,8 +10,8 @@ class MatchResult:
     """
     A record of the results of a match between two models.
     """
-    # model0_name: str
-    # model1_name: str
+    model0_name: str
+    model1_name: str
     model0_old_elo: float
     model1_old_elo: float
     model0_new_elo: float

--- a/lm_tournament_eval/api/model_utils.py
+++ b/lm_tournament_eval/api/model_utils.py
@@ -1,6 +1,9 @@
 import logging
 import lm_tournament_eval.models
 from lm_tournament_eval.api.registry import get_model
+from lm_tournament_eval.utils import (
+   simple_parse_args_string
+)
 
 def load_models(model_type, model0, model0_args, model1, model1_args, batch_size: int = 1,
                 max_batch_size: int = 1, device: str = "cuda:0"):

--- a/lm_tournament_eval/api/model_utils.py
+++ b/lm_tournament_eval/api/model_utils.py
@@ -1,0 +1,88 @@
+import logging
+import lm_tournament_eval.models
+from lm_tournament_eval.api.registry import get_model
+
+def load_models(model_type, model0, model0_args, model1, model1_args, batch_size: int = 1,
+                max_batch_size: int = 1, device: str = "cuda:0"):
+
+    # load model0 to device
+    if isinstance(model0, str):
+        if model0_args is None:
+            logging.warning("model0_args not specified. Using defaults")
+            model0_args = ""
+
+        if isinstance(model0_args, dict):
+            model0_args.update({"model": model0})
+            logging.info(
+                f"Initializing {model0} model, with arguments: {model0_args}."
+            )
+
+            lm0 = get_model(model_type).create_from_arg_obj(
+                model0_args,
+                {
+                    "batch_size" : batch_size,
+                    "max_batch_size" : max_batch_size,
+                    "device":  device,
+                },
+            )
+            
+        else:
+            model0_args += f"model={model0}"
+            logging.info(
+                f"Initializing {model0} model, with arguments: {simple_parse_args_string(model0_args)}"
+            )
+            lm0 = get_model(model_type).create_from_arg_string(
+                model0_args,
+                {
+                    "batch_size": batch_size,
+                    "max_batch_size": max_batch_size,
+                    "device": device,
+                }
+            )
+    else:
+        if not isinstance(model0, lm_tournament_eval.api.model.LM):
+            raise TypeError
+        logging.info("Using pre-initialized model")
+        lm0 = model0
+
+    # now do model1
+    if isinstance(model1, str):
+        if model1_args is None:
+            logging.warning("model1_args not specified. Using defaults")
+            model1_args = ""
+
+        if isinstance(model1_args, dict):
+            model1_args.update({"model": model1})
+            logging.info(
+                f"Initializing {model1} model, with arguments: {model1_args}."
+            )
+
+            lm1 = get_model(model_type).create_from_arg_obj(
+                model1_args,
+                {
+                    "batch_size" : batch_size,
+                    "max_batch_size" : max_batch_size,
+                    "device":  device,
+                },
+            )
+            
+        else:
+            model1_args += f"model={model1}"
+            logging.info(
+                f"Initializing {model1} model, with arguments: {simple_parse_args_string(model1_args)}"
+            )
+            lm1 = get_model(model_type).create_from_arg_string(
+                model1_args,
+                {
+                    "batch_size": batch_size,
+                    "max_batch_size": max_batch_size,
+                    "device": device,
+                }
+            )
+    else:
+        if not isinstance(model1, lm_tournament_eval.api.model.LM):
+            raise TypeError
+        logging.info(f"Using pre-initialized model for model 1.")
+        lm1 = model1
+
+    return lm0, lm1    

--- a/lm_tournament_eval/api/model_utils.py
+++ b/lm_tournament_eval/api/model_utils.py
@@ -1,41 +1,38 @@
 import logging
 import lm_tournament_eval.models
 from lm_tournament_eval.api.registry import get_model
-from lm_tournament_eval.utils import (
-   simple_parse_args_string
-)
+from lm_tournament_eval.utils import simple_parse_args_string
 
-def load_models(model_type, model0, model0_args, model1, model1_args, batch_size: int = 1,
-                max_batch_size: int = 1, device: str = "cuda:0"):
+def load_model(model_type, model, model_args, batch_size: int = 1,
+               max_batch_size: int = 1, device: str = "cuda:0"):
 
     # load model0 to device
-    if isinstance(model0, str):
-        if model0_args is None:
+    if isinstance(model, str):
+        if model_args is None:
             logging.warning("model0_args not specified. Using defaults")
-            model0_args = ""
+            model_args = ""
 
-        if isinstance(model0_args, dict):
-            model0_args.update({"model": model0})
+        if isinstance(model_args, dict):
+            model_args.update({"model": model})
             logging.info(
-                f"Initializing {model0} model, with arguments: {model0_args}."
+                f"Initializing {model} model, with arguments: {model_args}."
             )
 
-            lm0 = get_model(model_type).create_from_arg_obj(
-                model0_args,
+            lm = get_model(model_type).create_from_arg_obj(
+                model_args,
                 {
                     "batch_size" : batch_size,
                     "max_batch_size" : max_batch_size,
                     "device":  device,
                 },
             )
-            
         else:
-            model0_args += f"model={model0}"
+            model_args += f"model={model}"
             logging.info(
-                f"Initializing {model0} model, with arguments: {simple_parse_args_string(model0_args)}"
+                f"Initializing {model} model, with arguments: {simple_parse_args_string(model_args)}"
             )
-            lm0 = get_model(model_type).create_from_arg_string(
-                model0_args,
+            lm = get_model(model_type).create_from_arg_string(
+                model_args,
                 {
                     "batch_size": batch_size,
                     "max_batch_size": max_batch_size,
@@ -43,49 +40,9 @@ def load_models(model_type, model0, model0_args, model1, model1_args, batch_size
                 }
             )
     else:
-        if not isinstance(model0, lm_tournament_eval.api.model.LM):
+        if not isinstance(model, lm_tournament_eval.api.model.LM):
             raise TypeError
         logging.info("Using pre-initialized model")
-        lm0 = model0
+        lm = model
 
-    # now do model1
-    if isinstance(model1, str):
-        if model1_args is None:
-            logging.warning("model1_args not specified. Using defaults")
-            model1_args = ""
-
-        if isinstance(model1_args, dict):
-            model1_args.update({"model": model1})
-            logging.info(
-                f"Initializing {model1} model, with arguments: {model1_args}."
-            )
-
-            lm1 = get_model(model_type).create_from_arg_obj(
-                model1_args,
-                {
-                    "batch_size" : batch_size,
-                    "max_batch_size" : max_batch_size,
-                    "device":  device,
-                },
-            )
-            
-        else:
-            model1_args += f"model={model1}"
-            logging.info(
-                f"Initializing {model1} model, with arguments: {simple_parse_args_string(model1_args)}"
-            )
-            lm1 = get_model(model_type).create_from_arg_string(
-                model1_args,
-                {
-                    "batch_size": batch_size,
-                    "max_batch_size": max_batch_size,
-                    "device": device,
-                }
-            )
-    else:
-        if not isinstance(model1, lm_tournament_eval.api.model.LM):
-            raise TypeError
-        logging.info(f"Using pre-initialized model for model 1.")
-        lm1 = model1
-
-    return lm0, lm1    
+    return lm

--- a/lm_tournament_eval/api/offline_tournament.py
+++ b/lm_tournament_eval/api/offline_tournament.py
@@ -25,6 +25,7 @@ class OfflineTournamentConfig:
 class OfflineTournament:
     def __init__(self, config : OfflineTournamentConfig):
         self.config = config
+        self.elo = ELO()
         # read the offline results in 
         self.responses_0 = []
         self.responses_1 = []
@@ -40,21 +41,19 @@ class OfflineTournament:
         self.scheduler = OfflineMatchScheduler(self.scheduler_cfg)
         self.match_result_list = [MatchResult(model0_name=self.config.model0_name,
                                               model1_name=self.config.model1_name,           
-                                              model0_old_elo=self.score_0,
-                                              model1_old_elo=self.score_1,
-                                              model0_new_elo=self.score_0,
-                                              model1_new_elo=self.score_1,
-                                              task_config=self.config.task_config)
+                                              model0_old_elo=self.elo.score_0,
+                                              model1_old_elo=self.elo.score_1,
+                                              model0_new_elo=self.elo.score_0,
+                                              model1_new_elo=self.elo.score_1)
                                               for i in range(self.config.rounds)]
 
     def run_tournament(self):
-        elo = ELO()
         for n in range(self.config.rounds):
-            self.match_result_list[n].model0_old_elo = elo.score_0
-            self.match_result_list[n].model1_old_elo = elo.score_1
+            self.match_result_list[n].model0_old_elo = self.elo.score_0
+            self.match_result_list[n].model1_old_elo = self.elo.score_1
             task_indices = self.scheduler.schedule_tournament()
-            elo.offline_elo_update(self.responses_0, self.responses_1, task_names, task_indices)
-            self.match_result_list[n].model0_new_elo = elo.score_0
-            self.match_result_list[n].model1_new_elo = elo.score_1
+            self.elo.offline_elo_update(self.responses_0, self.responses_1, self.config.task_name, task_indices)
+            self.match_result_list[n].model0_new_elo = self.elo.score_0
+            self.match_result_list[n].model1_new_elo = self.elo.score_1
         return {}
 

--- a/lm_tournament_eval/api/task_utils.py
+++ b/lm_tournament_eval/api/task_utils.py
@@ -1,0 +1,136 @@
+import lm_tournament_eval.api.task
+from lm_tournament_eval.tasks import (
+    TaskManager,
+    get_task_dict
+)
+
+from lm_tournament_eval.evaluator_utils import (
+    get_subtask_list,
+    get_task_list,
+    get_sample_size
+)
+
+
+
+from lm_tournament_eval.utils import eval_logger
+from collections import defaultdict
+from typing import Optional, Union, Dict, List, Tuple
+
+
+def create_requests(tasks, task_manager, verbosity, limit, 
+                    predict_only: bool = False, 
+                    num_fewshot: Optional[int] = None,
+                    fewshot_random_seed: int = 1234,
+                    log_samples: bool = True    
+    ):
+    if task_manager is None:
+        task_manager = TaskManager(verbosity)
+
+    if tasks is None:
+        tasks = []
+    if len(tasks) == 0:
+        raise ValueError(
+            "No tasks specified, or no tasks found."
+        )
+
+    task_dict = get_task_dict(tasks, task_manager)
+    # helper function to recursively apply config overrides to leaf subtasks, skipping their constituent groups.
+    # (setting of num_fewshot ; bypassing metric calculation ; setting fewshot seed)
+    def _adjust_config(task_dict):
+        adjusted_task_dict = {}
+        for task_name, task_obj in task_dict.items():
+            if isinstance(task_obj, dict):
+                adjusted_task_dict = {
+                    **adjusted_task_dict,
+                    **{task_name: _adjust_config(task_obj)},
+                }
+
+            else:
+                if task_obj.get_config("output_type") == "generate_until":
+                    if gen_kwargs is not None:
+                        task_obj.set_config(
+                            key="generation_kwargs", value=gen_kwargs, update=True
+                        )
+
+                if predict_only:
+                    eval_logger.info(
+                        f"Processing {task_name} in output-only mode. Metrics will not be calculated!"
+                    )
+                    # we have to change the class properties post-hoc. This is pretty hacky.
+                    task_obj.override_metric(metric_name="bypass")
+
+                # override tasks' fewshot values to the provided num_fewshot arg value
+                # except if tasks have it set to 0 manually in their configs--then we should never overwrite that
+                if num_fewshot is not None:
+                    if (default_num_fewshot := task_obj.get_config("num_fewshot")) == 0:
+                        eval_logger.info(
+                            f"num_fewshot has been set to 0 for {task_name} in its config. Manual configuration will be ignored."
+                        )
+                    else:
+                        eval_logger.warning(
+                            f"Overwriting default num_fewshot of {task_name} from {default_num_fewshot} to {num_fewshot}"
+                        )
+                        task_obj.set_config(key="num_fewshot", value=num_fewshot)
+                else:
+                    # if num_fewshot not provided, and the task does not define a default one, default to 0
+                    if (
+                        default_num_fewshot := task_obj.get_config("num_fewshot")
+                    ) is None:
+                        task_obj.set_config(key="num_fewshot", value=0)
+                # fewshot_random_seed set for tasks, even with a default num_fewshot (e.g. in the YAML file)
+                task_obj.set_fewshot_seed(seed=fewshot_random_seed)
+                eval_logger.info(
+                    f"Setting fewshot random generator seed to {fewshot_random_seed}"
+                )
+
+                adjusted_task_dict[task_name] = task_obj
+
+        return adjusted_task_dict
+
+    task_dict = _adjust_config(task_dict)
+
+    # tracks all Instances/requests a model must generate output on.
+    requests = defaultdict(list)
+    # stores the amount to pad out reqs per req. type so that
+    # number of fwd passes per distributed rank is equal
+    padding_requests = defaultdict(int)
+
+    # get lists of group hierarchy and each type of request
+    eval_tasks = get_task_list(task_dict)
+    if not log_samples:
+        if not all(
+            "bypass" not in getattr(task_output.task, "_metric_fn_list", {}).keys()
+            for task_output in eval_tasks
+        ):
+            raise ValueError("log_samples must be True for 'bypass' metric-only tasks")
+
+    for task_output in eval_tasks:
+        task: Task = task_output.task
+        limit = get_sample_size(task, limit)
+        task.build_all_requests(
+            limit=limit,
+            rank=lm.rank,
+            world_size=lm.world_size,
+            cache_requests=cache_requests,
+            rewrite_requests_cache=rewrite_requests_cache,
+            system_instruction=system_instruction,
+            apply_chat_template=apply_chat_template,
+            fewshot_as_multiturn=fewshot_as_multiturn,
+            chat_template=getattr(lm, "apply_chat_template")
+            if apply_chat_template
+            else None,
+            tokenizer_name=getattr(lm, "tokenizer_name", "")
+            if apply_chat_template
+            else "",
+        )
+        eval_logger.debug(
+            f"Task: {task_output.task_name}; number of requests on this rank: {len(task.instances)}"
+        )
+        if write_out:
+            print_writeout(task)
+        # aggregate Instances by LM method requested to get output.
+        for instance in task.instances:
+            reqtype = instance.request_type
+            requests[reqtype].append(instance)
+    
+    return requests, eval_tasks

--- a/lm_tournament_eval/api/task_utils.py
+++ b/lm_tournament_eval/api/task_utils.py
@@ -1,14 +1,14 @@
-import lm_tournament_eval.api.task
 from lm_tournament_eval.tasks import (
     TaskManager,
     get_task_dict
 )
 
 from lm_tournament_eval.evaluator_utils import (
-    get_subtask_list,
     get_task_list,
-    get_sample_size
+    get_sample_size,
+    print_writeout
 )
+from lm_tournament_eval.api.task import Task
 
 from lm_tournament_eval.utils import eval_logger
 from collections import defaultdict

--- a/lm_tournament_eval/api/task_utils.py
+++ b/lm_tournament_eval/api/task_utils.py
@@ -10,17 +10,21 @@ from lm_tournament_eval.evaluator_utils import (
     get_sample_size
 )
 
-
-
 from lm_tournament_eval.utils import eval_logger
 from collections import defaultdict
 from typing import Optional, Union, Dict, List, Tuple
 
 
-def create_requests(tasks, task_manager, verbosity, limit, 
+def create_requests(lm, tasks, task_manager, verbosity, limit, 
                     predict_only: bool = False, 
                     num_fewshot: Optional[int] = None,
                     fewshot_random_seed: int = 1234,
+                    cache_requests: bool = False,
+                    rewrite_requests_cache: bool = False,
+                    apply_chat_template: bool = False,
+                    fewshot_as_multiturn: bool = False,
+                    system_instruction: Optional[str] = None,
+                    write_out: bool = False,
                     log_samples: bool = True    
     ):
     if task_manager is None:
@@ -133,4 +137,4 @@ def create_requests(tasks, task_manager, verbosity, limit,
             reqtype = instance.request_type
             requests[reqtype].append(instance)
     
-    return requests, eval_tasks
+    return requests, eval_tasks, task_dict

--- a/lm_tournament_eval/api/tournament.py
+++ b/lm_tournament_eval/api/tournament.py
@@ -7,62 +7,306 @@ from dataclasses import dataclass, field
 from .task import Task, TaskConfig
 
 from lm_tournament_eval.tasks import TaskManager
+from lm_tournament_eval.api.task_utils import create_requests
+
+from typing import Optional, Union, Dict, List, Tuple
+from lm_tournament_eval.loggers import EvaluationTracker
+from lm_tournament_eval.api.elo import ELO
+
 
 @dataclass
 class TournamentConfig:
     name : str
     model0_name : str
     model1_name : str
-    task_name : str
+    task_names : str
     rounds : int
+    batch_size : int
+    device : str
+    limit : int
 
 
 class Tournament:
-    def __init__(self, config : TournamentConfig):
-        pass
+    def __init__(self, config : TournamentConfig, tasks, task_manager, verbosity):
+        self.config = config
+        self.tasks = tasks
+        self.task_manager = task_manager
+        self.verbosity = verbosity
 
     def tournament_evaluate(
         self,
+        model_type,
         model0,
         model1,
-        tasks,
-        gen_kwargs,
-        task_manager,
-        random_seed,
-        numpy_random_seed,
-        torch_random_seed
-    ):
-        logging.info("Running tournament!")
+        requests,
+        eval_tasks,
+        model0_args: Optional[Union[str, dict]] = None,
+        model1_args: Optional[Union[str, dict]] = None,
+        num_fewshot: Optional[int] = None,
+        batch_size: Optional[Union[int, str]] = None,
+        max_batch_size: Optional[int] = None,
+        device: Optional[str] = None,
+        use_cache: Optional[str] = None,
+        cache_requests: bool = False,
+        rewrite_requests_cache: bool = False,
+        delete_requests_cache: bool = False,
+        limit: Optional[Union[int, float]] = None,
+        bootstrap_iters: int = 100000,
+        check_integrity: bool = False,
+        write_out: bool = False,
+        log_samples: bool = True,
+        evaluation_tracker: Optional[EvaluationTracker] = None,
+        system_instruction: Optional[str] = None,
+        apply_chat_template: bool = False,
+        fewshot_as_multiturn: bool = False,
+        gen_kwargs: Optional[str] = None,
+        verbosity: str = "INFO",
+        predict_only: bool = False,
+        random_seed: int = 0,
+        numpy_random_seed: int = 1234,
+        torch_random_seed: int = 1234,
+        fewshot_random_seed: int = 1234
+    ) -> Tuple[Dict, Dict]:
         
         start_date = time.time()
 
-        # TODO set random seeds
+        if delete_requests_cache:
+            logging.info("Deleteing requests cache.")
+            delete_cache()
 
-        if tasks is None:
-            tasks = []
-        if len(tasks) == 0:
-            raise ValueError(
-                "No tasks specified or no tasks found."
+        seed_message = []
+
+        if random_seed is not None:
+            seed_message.append(f"Setting random seed to {random_seed}")
+            random.seed(random_seed)
+
+        if numpy_random_seed is not None:
+            seed_message.append(f"Setting numpy seed to {numpy_random_seed}")
+            np.random.seed(numpy_random_seed)
+
+        if torch_random_seed is not None:
+            seed_message.append(f"Setting torch manual seed to {torch_random_seed}")
+            torch.manual_seed(torch_random_seed)
+
+        if seed_message:
+            logging.info(" | ".join(seed_message))
+        
+        if gen_kwargs is not None:
+            gen_kwargs = simple_parse_args_string(gen_kwargs)
+            logging.warning(
+                "generation_kwargs specified through cli, these settings will update set parameters in yaml tasks. "
+                "Ensure 'do_sample=True' for non-greedy decoding!"
             )
+            if gen_kwargs == "":
+                gen_kwargs = None
+
+        # LOAD MODEL0 to CPU
+        if isinstance(model0, str):
+            if model0_args is None:
+                logging.warning("model0_args not specified. Using defaults")
+                model0_args = ""
+
+            if isinstance(model0_args, dict):
+                model0_args.update({"model": model0})
+                logging.info(
+                    f"Initializing {model0} model, with arguments: {model0_args}."
+                )
+
+                lm0 = lm_tournament_eval.api.registry.get_model(model_type).create_from_arg_obj(
+                    model0_args,
+                    {
+                        "batch_size" : batch_size,
+                        "max_batch_size" : max_batch_size,
+                        "device":  device,
+                    },
+                )
+                
+            else:
+                model0_args += f"model={model0}"
+                logging.info(
+                    f"Initializing {model0} model, with arguments: {simple_parse_args_string(model0_args)}"
+                )
+                lm0 = lm_tournament_eval.api.registry.get_model(model_type).create_from_arg_string(
+                    model0_args,
+                    {
+                        "batch_size": batch_size,
+                        "max_batch_size": max_batch_size,
+                        "device": device,
+                    }
+                )
+        else:
+            if not isinstance(model0, lm_tournament_eval.api.model.LM):
+                raise TypeError
+            logging.info("Using pre-initialized model")
+            lm0 = model0
+
+        # now do model1
+        if isinstance(model1, str):
+            if model1_args is None:
+                logging.warning("model1_args not specified. Using defaults")
+                model1_args = ""
+
+            if isinstance(model1_args, dict):
+                model1_args.update({"model": model1})
+                logging.info(
+                    f"Initializing {model1} model, with arguments: {model1_args}."
+                )
+
+                lm1 = lm_tournament_eval.api.registry.get_model(model_type).create_from_arg_obj(
+                    model1_args,
+                    {
+                        "batch_size" : batch_size,
+                        "max_batch_size" : max_batch_size,
+                        "device":  device,
+                    },
+                )
+                
+            else:
+                model1_args += f"model={model1}"
+                logging.info(
+                    f"Initializing {model1} model, with arguments: {simple_parse_args_string(model1_args)}"
+                )
+                lm1 = lm_tournament_eval.api.registry.get_model(model_type).create_from_arg_string(
+                    model1_args,
+                    {
+                        "batch_size": batch_size,
+                        "max_batch_size": max_batch_size,
+                        "device": device,
+                    }
+                )
+        else:
+            if not isinstance(model1, lm_tournament_eval.api.model.LM):
+                raise TypeError
+            logging.info(f"Using pre-initialized model for model 1.")
+            lm1 = model1
+
+        # We don't currently support CachingLM
+
+        results0 = evaluate(
+            lm=lm0,
+            requests=requests,
+            eval_tasks=eval_tasks,
+            limit=limit,
+        )
+
+        results1 = evaluate(
+            lm=lm1,
+            requests=requests,
+            eval_tasks=eval_tasks,
+            limit=limit
+        )
+
+        # post-process results0 and results1
+        if lm0.rank == 0:
+            if isinstance(model0, str):
+                model0_name = model0
+            elif hasattr(model0, "config") and hasattr(model0.config, "_name_or_path"):
+                model0_name = model0.config._name_or_path
+            else:
+                model0_name = type(model0).__name__
+
+            results0["config"] = {
+                "model0": model0_name,
+                "model0_args": model0_args,
+            }
+
+            if isinstance(lm0, lm_tournament_eval.models.huggingface_model.HFLM):
+                results0["config"].update(lm0.get_model_info())
+
+            results0["config"].update(
+                {
+                    "batch_size": batch_size,
+                    "batch_sizes": (
+                        list(lm0.batch_sizes.values()) if hasattr(lm0, "batch_sizes") else []
+                    ),
+                    "device": device,
+                    "use_cache": use_cache,
+                    "limit": limit,
+                    "bootstrap_iters": bootstrap_iters,
+                    "gen_kwargs": gen_kwargs,
+                    "random_seed": random_seed,
+                    "numpy_seed": numpy_random_seed,
+                    "torch_seed": torch_random_seed,
+                    "fewshot_seed": fewshot_random_seed,
+                }
+            )
+
+            results0["git_hash"] = get_git_commit_hash()
+            results0["date"] = start_date
+            add_env_info(results0)  # additional environment info to results
+            add_tokenizer_info(results0, lm0)  # additional info about tokenizer
+        else:
+            return None
+
+        if lm1.rank == 0:
+            if isinstance(model1, str):
+                model1_name = model1
+            elif hasattr(model1, "config") and hasattr(model1.config, "_name_or_path"):
+                model1_name = model1.config._name_or_path
+            else:
+                model1_name = type(model1).__name__
+
+            results1["config"] = {
+                "model1": model1_name,
+                "model1_args": model1_args,
+            }
+
+            if isinstance(lm1, lm_tournament_eval.models.huggingface_model.HFLM):
+                results1["config"].update(lm1.get_model_info())
+
+            results1["config"].update(
+                {
+                    "batch_size": batch_size,
+                    "batch_sizes": (
+                        list(lm1.batch_sizes.values()) if hasattr(lm1, "batch_sizes") else []
+                    ),
+                    "device": device,
+                    "use_cache": use_cache,
+                    "limit": limit,
+                    "bootstrap_iters": bootstrap_iters,
+                    "gen_kwargs": gen_kwargs,
+                    "random_seed": random_seed,
+                    "numpy_seed": numpy_random_seed,
+                    "torch_seed": torch_random_seed,
+                    "fewshot_seed": fewshot_random_seed,
+                }
+            )
+
+            results1["git_hash"] = get_git_commit_hash()
+            results1["date"] = start_date
+            add_env_info(results1)  # additional environment info to results
+            add_tokenizer_info(results1, lm1)  # additional info about tokenizer
+        else:
+            return None
         
-        # TODO set up gen_kwargs
+        return (results0, results1)
 
-        # TODO handle model initialization. TODO decide if we want to allow strings.
-
-        if task_manager is None:
-            task_manager = TaskManager()
-
-        # TODO setup match parameters
-
-        
-
-        # for number of rounds
-        # create match
-        # run match
-        # record results
-        # update Elo
-
-        return {}
-
-
-    
+    def run_tournament(self):
+        elo = ELO()
+        #TODO: create function that initializes the models; ie. rip the code out of tournament_evaluate
+        #      pass the one of the models into create requests
+        requests, eval_tasks = create_requests(
+                self.tasks,
+                self.task_manager,
+                self.verbosity,
+                self.config.limit)
+                #TODO: add all the other params here so that build_all_requests is happy 
+        # for rounds:
+        for round in range(self.config.rounds):
+            #TODO: create subset of requests of len(match_size)
+            
+            #run tournament evaluate on that subset
+            results0, results1 = tournament_evaluate(
+                model_type="hf",
+                model0=self.config.model0_name,
+                model1=self.config.model1_name,
+                model0_args=self.config.model0_args,
+                model1_args=self.config.model1_args,
+                requests = requests,
+                eval_tasks=eval_tasks,
+                batch_size=self.config.batch_size,
+                device=self.config.device,
+                limit=self.config.limit
+            )
+            #calculate ELO updates
+            elo.online_elo_update(results0, results1, self.config.task_name)

--- a/lm_tournament_eval/api/tournament.py
+++ b/lm_tournament_eval/api/tournament.py
@@ -2,17 +2,29 @@
 
 import logging
 import time
+import random
+import numpy as np
+import torch
 
 from dataclasses import dataclass, field
 from .task import Task, TaskConfig
 
 from lm_tournament_eval.tasks import TaskManager
 from lm_tournament_eval.api.task_utils import create_requests
+from lm_tournament_eval.api.model_utils import load_models
+from lm_tournament_eval.tournament_evaluator import evaluate
 
 from typing import Optional, Union, Dict, List, Tuple
 from lm_tournament_eval.loggers import EvaluationTracker
 from lm_tournament_eval.api.elo import ELO
+from lm_tournament_eval.utils import eval_logger
+from lm_tournament_eval.models.huggingface_model import HFLM
 
+from lm_tournament_eval.loggers.utils import (
+     add_env_info, 
+     add_tokenizer_info, 
+     get_git_commit_hash
+)
 
 @dataclass
 class TournamentConfig:
@@ -36,29 +48,23 @@ class Tournament:
     def tournament_evaluate(
         self,
         model_type,
-        model0,
-        model1,
+        model,
+        lm,
         requests,
         eval_tasks,
-        model0_args: Optional[Union[str, dict]] = None,
-        model1_args: Optional[Union[str, dict]] = None,
+        task_dict,
+        model_args: Optional[Union[str, dict]] = None,
         num_fewshot: Optional[int] = None,
         batch_size: Optional[Union[int, str]] = None,
         max_batch_size: Optional[int] = None,
         device: Optional[str] = None,
         use_cache: Optional[str] = None,
-        cache_requests: bool = False,
-        rewrite_requests_cache: bool = False,
         delete_requests_cache: bool = False,
         limit: Optional[Union[int, float]] = None,
         bootstrap_iters: int = 100000,
         check_integrity: bool = False,
-        write_out: bool = False,
         log_samples: bool = True,
         evaluation_tracker: Optional[EvaluationTracker] = None,
-        system_instruction: Optional[str] = None,
-        apply_chat_template: bool = False,
-        fewshot_as_multiturn: bool = False,
         gen_kwargs: Optional[str] = None,
         verbosity: str = "INFO",
         predict_only: bool = False,
@@ -100,124 +106,38 @@ class Tournament:
             if gen_kwargs == "":
                 gen_kwargs = None
 
-        # LOAD MODEL0 to CPU
-        if isinstance(model0, str):
-            if model0_args is None:
-                logging.warning("model0_args not specified. Using defaults")
-                model0_args = ""
-
-            if isinstance(model0_args, dict):
-                model0_args.update({"model": model0})
-                logging.info(
-                    f"Initializing {model0} model, with arguments: {model0_args}."
-                )
-
-                lm0 = lm_tournament_eval.api.registry.get_model(model_type).create_from_arg_obj(
-                    model0_args,
-                    {
-                        "batch_size" : batch_size,
-                        "max_batch_size" : max_batch_size,
-                        "device":  device,
-                    },
-                )
-                
-            else:
-                model0_args += f"model={model0}"
-                logging.info(
-                    f"Initializing {model0} model, with arguments: {simple_parse_args_string(model0_args)}"
-                )
-                lm0 = lm_tournament_eval.api.registry.get_model(model_type).create_from_arg_string(
-                    model0_args,
-                    {
-                        "batch_size": batch_size,
-                        "max_batch_size": max_batch_size,
-                        "device": device,
-                    }
-                )
-        else:
-            if not isinstance(model0, lm_tournament_eval.api.model.LM):
-                raise TypeError
-            logging.info("Using pre-initialized model")
-            lm0 = model0
-
-        # now do model1
-        if isinstance(model1, str):
-            if model1_args is None:
-                logging.warning("model1_args not specified. Using defaults")
-                model1_args = ""
-
-            if isinstance(model1_args, dict):
-                model1_args.update({"model": model1})
-                logging.info(
-                    f"Initializing {model1} model, with arguments: {model1_args}."
-                )
-
-                lm1 = lm_tournament_eval.api.registry.get_model(model_type).create_from_arg_obj(
-                    model1_args,
-                    {
-                        "batch_size" : batch_size,
-                        "max_batch_size" : max_batch_size,
-                        "device":  device,
-                    },
-                )
-                
-            else:
-                model1_args += f"model={model1}"
-                logging.info(
-                    f"Initializing {model1} model, with arguments: {simple_parse_args_string(model1_args)}"
-                )
-                lm1 = lm_tournament_eval.api.registry.get_model(model_type).create_from_arg_string(
-                    model1_args,
-                    {
-                        "batch_size": batch_size,
-                        "max_batch_size": max_batch_size,
-                        "device": device,
-                    }
-                )
-        else:
-            if not isinstance(model1, lm_tournament_eval.api.model.LM):
-                raise TypeError
-            logging.info(f"Using pre-initialized model for model 1.")
-            lm1 = model1
-
         # We don't currently support CachingLM
 
-        results0 = evaluate(
-            lm=lm0,
+        results = evaluate(
+            lm=lm,
             requests=requests,
             eval_tasks=eval_tasks,
+            task_dict=task_dict,
             limit=limit,
         )
 
-        results1 = evaluate(
-            lm=lm1,
-            requests=requests,
-            eval_tasks=eval_tasks,
-            limit=limit
-        )
-
-        # post-process results0 and results1
-        if lm0.rank == 0:
-            if isinstance(model0, str):
-                model0_name = model0
-            elif hasattr(model0, "config") and hasattr(model0.config, "_name_or_path"):
-                model0_name = model0.config._name_or_path
+        # post-process results
+        if lm.rank == 0:
+            if isinstance(model, str):
+                model_name = model
+            elif hasattr(model, "config") and hasattr(model.config, "_name_or_path"):
+                model_name = model.config._name_or_path
             else:
-                model0_name = type(model0).__name__
+                model_name = type(model).__name__
 
-            results0["config"] = {
-                "model0": model0_name,
-                "model0_args": model0_args,
+            results["config"] = {
+                "model": model_name,
+                "model_args": model_args,
             }
 
-            if isinstance(lm0, lm_tournament_eval.models.huggingface_model.HFLM):
-                results0["config"].update(lm0.get_model_info())
+            if isinstance(lm, HFLM):
+                results["config"].update(lm.get_model_info())
 
-            results0["config"].update(
+            results["config"].update(
                 {
                     "batch_size": batch_size,
                     "batch_sizes": (
-                        list(lm0.batch_sizes.values()) if hasattr(lm0, "batch_sizes") else []
+                        list(lm.batch_sizes.values()) if hasattr(lm, "batch_sizes") else []
                     ),
                     "device": device,
                     "use_cache": use_cache,
@@ -231,82 +151,70 @@ class Tournament:
                 }
             )
 
-            results0["git_hash"] = get_git_commit_hash()
-            results0["date"] = start_date
-            add_env_info(results0)  # additional environment info to results
-            add_tokenizer_info(results0, lm0)  # additional info about tokenizer
+            results["git_hash"] = get_git_commit_hash()
+            results["date"] = start_date
+            add_env_info(results)  # additional environment info to results
+            add_tokenizer_info(results, lm)  # additional info about tokenizer
         else:
             return None
 
-        if lm1.rank == 0:
-            if isinstance(model1, str):
-                model1_name = model1
-            elif hasattr(model1, "config") and hasattr(model1.config, "_name_or_path"):
-                model1_name = model1.config._name_or_path
-            else:
-                model1_name = type(model1).__name__
-
-            results1["config"] = {
-                "model1": model1_name,
-                "model1_args": model1_args,
-            }
-
-            if isinstance(lm1, lm_tournament_eval.models.huggingface_model.HFLM):
-                results1["config"].update(lm1.get_model_info())
-
-            results1["config"].update(
-                {
-                    "batch_size": batch_size,
-                    "batch_sizes": (
-                        list(lm1.batch_sizes.values()) if hasattr(lm1, "batch_sizes") else []
-                    ),
-                    "device": device,
-                    "use_cache": use_cache,
-                    "limit": limit,
-                    "bootstrap_iters": bootstrap_iters,
-                    "gen_kwargs": gen_kwargs,
-                    "random_seed": random_seed,
-                    "numpy_seed": numpy_random_seed,
-                    "torch_seed": torch_random_seed,
-                    "fewshot_seed": fewshot_random_seed,
-                }
-            )
-
-            results1["git_hash"] = get_git_commit_hash()
-            results1["date"] = start_date
-            add_env_info(results1)  # additional environment info to results
-            add_tokenizer_info(results1, lm1)  # additional info about tokenizer
-        else:
-            return None
-        
-        return (results0, results1)
+        return results
 
     def run_tournament(self):
         elo = ELO()
         #TODO: create function that initializes the models; ie. rip the code out of tournament_evaluate
         #      pass the one of the models into create requests
-        requests, eval_tasks = create_requests(
+
+        model0, model1 = load_models("hf", self.config.model0_name, {}, #self.config.model0_args,
+                                     self.config.model1_name, {}) #self.config.model1_args)
+
+        requests0, eval_tasks0, task_dict0 = create_requests(
+                model0,
                 self.tasks,
                 self.task_manager,
                 self.verbosity,
                 self.config.limit)
                 #TODO: add all the other params here so that build_all_requests is happy 
+        requests1, eval_tasks1, task_dict1 = create_requests(
+                model1,
+                self.tasks,
+                self.task_manager,
+                self.verbosity,
+                self.config.limit)
+                #TODO: add all the other params here so that build_all_requests is happy 
+
+
         # for rounds:
         for round in range(self.config.rounds):
+
             #TODO: create subset of requests of len(match_size)
-            
+
             #run tournament evaluate on that subset
-            results0, results1 = tournament_evaluate(
+            results0 = self.tournament_evaluate(
                 model_type="hf",
-                model0=self.config.model0_name,
-                model1=self.config.model1_name,
-                model0_args=self.config.model0_args,
-                model1_args=self.config.model1_args,
-                requests = requests,
-                eval_tasks=eval_tasks,
+                model=self.config.model0_name,
+                lm=model0,
+                model_args={}, #self.config.model0_args,
+                requests=requests0,
+                eval_tasks=eval_tasks0,
+                task_dict=task_dict0,
                 batch_size=self.config.batch_size,
                 device=self.config.device,
                 limit=self.config.limit
             )
+            results1 = self.tournament_evaluate(
+                model_type="hf",
+                model=self.config.model1_name, 
+                lm=model1,
+                model_args=  {}, #self.config.model1_args,
+                requests=requests1,
+                eval_tasks=eval_tasks1,
+                task_dict=task_dict1,
+                batch_size=self.config.batch_size,
+                device=self.config.device,
+                limit=self.config.limit
+            )            
             #calculate ELO updates
-            elo.online_elo_update(results0, results1, self.config.task_name)
+            elo.online_elo_update(results0, results1, self.config.task_names)
+
+

--- a/lm_tournament_eval/api/tournament.py
+++ b/lm_tournament_eval/api/tournament.py
@@ -38,6 +38,7 @@ class TournamentConfig:
     batch_size : int
     device : str
     limit : int
+    match_size : int 
 
 
 class Tournament:
@@ -159,60 +160,55 @@ class Tournament:
         #TODO: create function that initializes the models; ie. rip the code out of tournament_evaluate
         #      pass the one of the models into create requests
 
-        model0 = load_model("hf", self.config.model0_name,
-                                   self.config.model0_args,
-                                   batch_size=self.config.batch_size,
-                                   max_batch_size=self.config.batch_size)
+        model0 = load_model("hf", 
+                            self.config.model0_name,
+                            self.config.model0_args,
+                            batch_size=self.config.batch_size,
+                            max_batch_size=self.config.batch_size)
 
-        model1 = load_model("hf", self.config.model1_name,
-                                   self.config.model1_args,
-                                   batch_size=self.config.batch_size,
-                                   max_batch_size=self.config.batch_size)
+        model1 = load_model("hf",
+                            self.config.model1_name,
+                            self.config.model1_args,
+                            batch_size=self.config.batch_size,
+                            max_batch_size=self.config.batch_size)
 
-        requests0, eval_tasks0, task_dict0 = create_requests(
-                model0,
-                self.tasks,
-                self.task_manager,
-                self.verbosity,
-                self.config.limit)
+        requests0, eval_tasks0, task_dict0 = create_requests(model0,
+                                                             self.tasks,
+                                                             self.task_manager,
+                                                             self.verbosity,
+                                                             self.config.limit)
                 #TODO: add all the other params here so that build_all_requests is happy 
-        requests1, eval_tasks1, task_dict1 = create_requests(
-                model1,
-                self.tasks,
-                self.task_manager,
-                self.verbosity,
-                self.config.limit)
+        requests1, eval_tasks1, task_dict1 = create_requests(model1,
+                                                             self.tasks,
+                                                             self.task_manager,
+                                                             self.verbosity,
+                                                             self.config.limit)
                 #TODO: add all the other params here so that build_all_requests is happy 
 
 
         # for rounds:
         for round in range(self.config.rounds):
-
             #TODO: create subset of requests of len(match_size)
             #run tournament evaluate on that subset
-            results0 = self.tournament_evaluate(
-                model=self.config.model0_name,
-                lm=model0,
-                model_args=self.config.model0_args,
-                requests=requests0,
-                eval_tasks=eval_tasks0,
-                task_dict=task_dict0,
-                batch_size=self.config.batch_size,
-                device=self.config.device,
-                limit=self.config.limit
-            )
-            results1 = self.tournament_evaluate(
-                model=self.config.model1_name, 
-                lm=model1,
-                model_args=self.config.model1_args,
-                requests=requests1,
-                eval_tasks=eval_tasks1,
-                task_dict=task_dict1,
-                batch_size=self.config.batch_size,
-                device=self.config.device,
-                limit=self.config.limit
-            )            
+            results0 = self.tournament_evaluate(model=self.config.model0_name,
+                                                lm=model0,
+                                                model_args=self.config.model0_args,
+                                                requests=requests0,
+                                                eval_tasks=eval_tasks0,
+                                                task_dict=task_dict0,
+                                                batch_size=self.config.batch_size,
+                                                device=self.config.device,
+                                                limit=self.config.limit
+                                            )
+            results1 = self.tournament_evaluate(model=self.config.model1_name,
+                                                lm=model1,
+                                                model_args=self.config.model1_args,
+                                                requests=requests1,
+                                                eval_tasks=eval_tasks1,
+                                                task_dict=task_dict1,
+                                                batch_size=self.config.batch_size,
+                                                device=self.config.device,
+                                                limit=self.config.limit
+                                            )
             #calculate ELO updates
-            elo.online_elo_update(results0, results1, self.config.task_names)
-
-
+            elo.online_elo_update(results0, results1, self.config.task_names, self.config.match_size)

--- a/lm_tournament_eval/api/tournament.py
+++ b/lm_tournament_eval/api/tournament.py
@@ -29,7 +29,9 @@ from lm_tournament_eval.loggers.utils import (
 class TournamentConfig:
     name : str
     model0_name : str
+    model0_args : str
     model1_name : str
+    model1_args : str
     task_names : str
     rounds : int
     batch_size : int
@@ -164,8 +166,12 @@ class Tournament:
         #TODO: create function that initializes the models; ie. rip the code out of tournament_evaluate
         #      pass the one of the models into create requests
 
-        model0, model1 = load_models("hf", self.config.model0_name, {}, #self.config.model0_args,
-                                     self.config.model1_name, {}, batch_size=self.config.batch_size, max_batch_size=self.config.batch_size) #self.config.model1_args)
+        model0, model1 = load_models("hf", self.config.model0_name,
+                                     self.config.model0_args,
+                                     self.config.model1_name,
+                                     self.config.model1_args,
+                                     batch_size=self.config.batch_size,
+                                     max_batch_size=self.config.batch_size)
 
         requests0, eval_tasks0, task_dict0 = create_requests(
                 model0,
@@ -192,7 +198,7 @@ class Tournament:
                 model_type="hf",
                 model=self.config.model0_name,
                 lm=model0,
-                model_args={}, #self.config.model0_args,
+                model_args=self.config.model0_args,
                 requests=requests0,
                 eval_tasks=eval_tasks0,
                 task_dict=task_dict0,
@@ -204,7 +210,7 @@ class Tournament:
                 model_type="hf",
                 model=self.config.model1_name, 
                 lm=model1,
-                model_args=  {}, #self.config.model1_args,
+                model_args=self.config.model1_args,
                 requests=requests1,
                 eval_tasks=eval_tasks1,
                 task_dict=task_dict1,

--- a/lm_tournament_eval/api/tournament.py
+++ b/lm_tournament_eval/api/tournament.py
@@ -6,7 +6,7 @@ import random
 import numpy as np
 import torch
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from .task import Task, TaskConfig
 
 from lm_tournament_eval.tasks import TaskManager
@@ -17,7 +17,6 @@ from lm_tournament_eval.tournament_evaluator import evaluate
 from typing import Optional, Union, Dict, List, Tuple
 from lm_tournament_eval.loggers import EvaluationTracker
 from lm_tournament_eval.api.elo import ELO
-from lm_tournament_eval.utils import eval_logger
 from lm_tournament_eval.models.huggingface_model import HFLM
 
 from lm_tournament_eval.loggers.utils import (
@@ -47,12 +46,12 @@ class Tournament:
 
     def tournament_evaluate(
         self,
-        model_type,
-        model,
-        lm,
-        requests,
-        eval_tasks,
-        task_dict,
+        model_type: str,
+        model: str,
+        lm: HFLM,
+        requests: Dict,
+        eval_tasks: List,
+        task_dict: Dict,
         model_args: Optional[Union[str, dict]] = None,
         num_fewshot: Optional[int] = None,
         batch_size: Optional[Union[int, str]] = None,
@@ -72,8 +71,8 @@ class Tournament:
         numpy_random_seed: int = 1234,
         torch_random_seed: int = 1234,
         fewshot_random_seed: int = 1234
-    ) -> Tuple[Dict, Dict]:
-        
+    ) -> Dict:
+
         start_date = time.time()
 
         if delete_requests_cache:
@@ -166,7 +165,7 @@ class Tournament:
         #      pass the one of the models into create requests
 
         model0, model1 = load_models("hf", self.config.model0_name, {}, #self.config.model0_args,
-                                     self.config.model1_name, {}) #self.config.model1_args)
+                                     self.config.model1_name, {}, batch_size=self.config.batch_size, max_batch_size=self.config.batch_size) #self.config.model1_args)
 
         requests0, eval_tasks0, task_dict0 = create_requests(
                 model0,
@@ -188,7 +187,6 @@ class Tournament:
         for round in range(self.config.rounds):
 
             #TODO: create subset of requests of len(match_size)
-
             #run tournament evaluate on that subset
             results0 = self.tournament_evaluate(
                 model_type="hf",

--- a/lm_tournament_eval/api/tournament.py
+++ b/lm_tournament_eval/api/tournament.py
@@ -55,6 +55,7 @@ class Tournament:
         requests: Dict,
         eval_tasks: List,
         task_dict: Dict,
+        padding_requests: Dict,
         model_args: Optional[Union[str, dict]] = None,
         batch_size: Optional[Union[int, str]] = None,
         device: Optional[str] = None,
@@ -108,6 +109,7 @@ class Tournament:
             requests=requests,
             eval_tasks=eval_tasks,
             task_dict=task_dict,
+            padding_requests=padding_requests,
             limit=limit,
         )
 
@@ -172,17 +174,17 @@ class Tournament:
                             batch_size=self.config.batch_size,
                             max_batch_size=self.config.batch_size)
 
-        requests0, eval_tasks0, task_dict0 = create_requests(model0,
-                                                             self.tasks,
-                                                             self.task_manager,
-                                                             self.verbosity,
-                                                             self.config.limit)
+        requests0, eval_tasks0, task_dict0, padding_reqests0 = create_requests(model0,
+                                                                               self.tasks,
+                                                                               self.task_manager,
+                                                                               self.verbosity,
+                                                                               self.config.limit)
                 #TODO: add all the other params here so that build_all_requests is happy 
-        requests1, eval_tasks1, task_dict1 = create_requests(model1,
-                                                             self.tasks,
-                                                             self.task_manager,
-                                                             self.verbosity,
-                                                             self.config.limit)
+        requests1, eval_tasks1, task_dict1, padding_reqests1 = create_requests(model1,
+                                                                               self.tasks,
+                                                                               self.task_manager,
+                                                                               self.verbosity,
+                                                                               self.config.limit)
                 #TODO: add all the other params here so that build_all_requests is happy 
 
 
@@ -196,6 +198,7 @@ class Tournament:
                                                 requests=requests0,
                                                 eval_tasks=eval_tasks0,
                                                 task_dict=task_dict0,
+                                                padding_requests=padding_reqests0,
                                                 batch_size=self.config.batch_size,
                                                 device=self.config.device,
                                                 limit=self.config.limit
@@ -206,6 +209,7 @@ class Tournament:
                                                 requests=requests1,
                                                 eval_tasks=eval_tasks1,
                                                 task_dict=task_dict1,
+                                                padding_requests=padding_reqests1,
                                                 batch_size=self.config.batch_size,
                                                 device=self.config.device,
                                                 limit=self.config.limit

--- a/lm_tournament_eval/models/huggingface_model.py
+++ b/lm_tournament_eval/models/huggingface_model.py
@@ -20,6 +20,8 @@ from ..api.lm_utils import (
     stop_sequences_criteria
 )
 
+from tqdm import tqdm
+
 from typing import List, Tuple, Union, Optional
 
 # from lm_eval/models/utils.py
@@ -302,6 +304,11 @@ class HFLM(LM):
         batch_size = self.batch_size
         chunks = re_ord.get_batched(n=batch_size, batch_fn=None)
 
+        pbar = tqdm(
+            total=len(requests),
+            desc="Running loglikelihood requests",
+        )
+
         for chunk in chunks:
             inps = []
             cont_toks_list = []
@@ -368,6 +375,8 @@ class HFLM(LM):
 
                         answer = (float(logits.sum()), bool(max_equal))
                         res.append(answer)
+                        pbar.update(1)
+        pbar.close()
 
         return re_ord.get_original(res)
             

--- a/lm_tournament_eval/tournament_evaluator.py
+++ b/lm_tournament_eval/tournament_evaluator.py
@@ -32,6 +32,7 @@ def evaluate(
     requests,
     eval_tasks,
     task_dict,
+    padding_requests,
     limit: Optional[int] = None,
     bootstrap_iters: Optional[int] = 100000,
     log_samples: bool = True,
@@ -62,24 +63,6 @@ def evaluate(
     """
 
     eval_logger.setLevel(getattr(logging, f"{verbosity}"))
-
-
-
-    if lm.world_size > 1:
-        instances_rnk = torch.tensor(len(task._instances), device=lm.device)
-        gathered_item = (
-            lm.accelerator.gather(instances_rnk).cpu().detach().numpy().tolist()
-        )
-        # "multiple_choice" task types dispatch (several) "loglikelihood" request types
-        reqtype = (
-            "loglikelihood"
-            if task.OUTPUT_TYPE == "multiple_choice"
-            else task.OUTPUT_TYPE
-        )
-        # compute number of pseudo-batches to pad with (FSDP/DDP require even batches among ranks)
-        numpad = max(gathered_item) - gathered_item[lm.rank]
-        # todo: may not account for padding in cases like SquadV2 which has multiple req types
-        padding_requests[reqtype] += numpad
 
     ### Run LM on inputs, get all outputs ###
     # execute each type of request

--- a/lm_tournament_eval/tournament_evaluator.py
+++ b/lm_tournament_eval/tournament_evaluator.py
@@ -1,14 +1,9 @@
-import time
 import logging
-from typing import Optional, Union, Dict, List, Tuple
-import random
+from typing import Optional
 import json
 from collections import defaultdict
 
 import itertools
-
-import numpy as np
-
 import torch
 
 import lm_tournament_eval.api.registry
@@ -19,27 +14,17 @@ from lm_tournament_eval.api.task import Task
 import lm_tournament_eval.models
 from lm_tournament_eval.api.model import LM
 
-from lm_tournament_eval.loggers import EvaluationTracker
-
-from lm_tournament_eval.caching.cache import delete_cache
-
 from lm_tournament_eval.utils import (
     eval_logger,
     handle_non_serializable,
     hash_string,
-    positional_deprecated,
-    simple_parse_args_string,
 )
 
 from lm_tournament_eval.evaluator_utils import (
     consolidate_group_results,
     consolidate_results,
-    get_sample_size,
     get_subtask_list,
-    get_task_list,
     prepare_print_tasks,
-    print_writeout,
-    run_task_tests,
 )
 
 def evaluate(
@@ -48,14 +33,8 @@ def evaluate(
     eval_tasks,
     task_dict,
     limit: Optional[int] = None,
-    cache_requests: bool = False,
-    rewrite_requests_cache: bool = False,
     bootstrap_iters: Optional[int] = 100000,
-    write_out: bool = False,
     log_samples: bool = True,
-    system_instruction: Optional[str] = None,
-    apply_chat_template: bool = False,
-    fewshot_as_multiturn: bool = False,
     verbosity: str = "INFO",
 ):
     """Instantiate and evaluate a model on a list of tasks.

--- a/lm_tournament_eval/tournament_evaluator.py
+++ b/lm_tournament_eval/tournament_evaluator.py
@@ -16,11 +16,6 @@ import lm_tournament_eval.api.task
 import lm_tournament_eval.models
 
 from lm_tournament_eval.loggers import EvaluationTracker
-from lm_tournament_eval.loggers.utils import (
-     add_env_info, 
-     add_tokenizer_info, 
-     get_git_commit_hash
-)
 
 from lm_tournament_eval.caching.cache import delete_cache
 
@@ -47,6 +42,7 @@ def evaluate(
     lm: "LM",
     requests,
     eval_tasks,
+    task_dict,
     limit: Optional[int] = None,
     cache_requests: bool = False,
     rewrite_requests_cache: bool = False,

--- a/lm_tournament_eval/tournament_evaluator.py
+++ b/lm_tournament_eval/tournament_evaluator.py
@@ -22,10 +22,6 @@ from lm_tournament_eval.loggers.utils import (
      get_git_commit_hash
 )
 
-from lm_tournament_eval.tasks import (
-    TaskManager,
-    get_task_dict
-)
 from lm_tournament_eval.caching.cache import delete_cache
 
 from lm_tournament_eval.utils import (
@@ -47,321 +43,10 @@ from lm_tournament_eval.evaluator_utils import (
     run_task_tests,
 )
 
-def tournament_evaluate(
-    model_type,
-    model0,
-    model1,
-    model0_args: Optional[Union[str, dict]] = None,
-    model1_args: Optional[Union[str, dict]] = None,
-    tasks: Optional[List[Union[str, dict, object]]] = None,
-    num_fewshot: Optional[int] = None,
-    batch_size: Optional[Union[int, str]] = None,
-    max_batch_size: Optional[int] = None,
-    device: Optional[str] = None,
-    use_cache: Optional[str] = None,
-    cache_requests: bool = False,
-    rewrite_requests_cache: bool = False,
-    delete_requests_cache: bool = False,
-    limit: Optional[Union[int, float]] = None,
-    bootstrap_iters: int = 100000,
-    check_integrity: bool = False,
-    write_out: bool = False,
-    log_samples: bool = True,
-    evaluation_tracker: Optional[EvaluationTracker] = None,
-    system_instruction: Optional[str] = None,
-    apply_chat_template: bool = False,
-    fewshot_as_multiturn: bool = False,
-    gen_kwargs: Optional[str] = None,
-    task_manager: Optional[TaskManager] = None,
-    verbosity: str = "INFO",
-    predict_only: bool = False,
-    random_seed: int = 0,
-    numpy_random_seed: int = 1234,
-    torch_random_seed: int = 1234,
-    fewshot_random_seed: int = 1234
-) -> Tuple[Dict, Dict]:
-    
-    start_date = time.time()
-
-    if delete_requests_cache:
-        logging.info("Deleteing requests cache.")
-        delete_cache()
-
-    seed_message = []
-
-    if random_seed is not None:
-        seed_message.append(f"Setting random seed to {random_seed}")
-        random.seed(random_seed)
-
-    if numpy_random_seed is not None:
-        seed_message.append(f"Setting numpy seed to {numpy_random_seed}")
-        np.random.seed(numpy_random_seed)
-
-    if torch_random_seed is not None:
-        seed_message.append(f"Setting torch manual seed to {torch_random_seed}")
-        torch.manual_seed(torch_random_seed)
-
-    if seed_message:
-        logging.info(" | ".join(seed_message))
-
-    if tasks is None:
-        tasks = []
-    if len(tasks) == 0:
-        raise ValueError(
-            "No tasks specified, or no tasks found."
-        )
-    
-    if gen_kwargs is not None:
-        gen_kwargs = simple_parse_args_string(gen_kwargs)
-        logging.warning(
-            "generation_kwargs specified through cli, these settings will update set parameters in yaml tasks. "
-            "Ensure 'do_sample=True' for non-greedy decoding!"
-        )
-        if gen_kwargs == "":
-            gen_kwargs = None
-
-    # LOAD MODEL0 to CPU
-    if isinstance(model0, str):
-        if model0_args is None:
-            logging.warning("model0_args not specified. Using defaults")
-            model0_args = ""
-
-        if isinstance(model0_args, dict):
-            model0_args.update({"model": model0})
-            logging.info(
-                f"Initializing {model0} model, with arguments: {model0_args}."
-            )
-
-            lm0 = lm_tournament_eval.api.registry.get_model(model_type).create_from_arg_obj(
-                model0_args,
-                {
-                    "batch_size" : batch_size,
-                    "max_batch_size" : max_batch_size,
-                    "device":  device,
-                },
-            )
-            
-        else:
-            model0_args += f"model={model0}"
-            logging.info(
-                f"Initializing {model0} model, with arguments: {simple_parse_args_string(model0_args)}"
-            )
-            lm0 = lm_tournament_eval.api.registry.get_model(model_type).create_from_arg_string(
-                model0_args,
-                {
-                    "batch_size": batch_size,
-                    "max_batch_size": max_batch_size,
-                    "device": device,
-                }
-            )
-    else:
-        if not isinstance(model0, lm_tournament_eval.api.model.LM):
-            raise TypeError
-        logging.info("Using pre-initialized model")
-        lm0 = model0
-
-    # now do model1
-    if isinstance(model1, str):
-        if model1_args is None:
-            logging.warning("model1_args not specified. Using defaults")
-            model1_args = ""
-
-        if isinstance(model1_args, dict):
-            model1_args.update({"model": model1})
-            logging.info(
-                f"Initializing {model1} model, with arguments: {model1_args}."
-            )
-
-            lm1 = lm_tournament_eval.api.registry.get_model(model_type).create_from_arg_obj(
-                model1_args,
-                {
-                    "batch_size" : batch_size,
-                    "max_batch_size" : max_batch_size,
-                    "device":  device,
-                },
-            )
-            
-        else:
-            model1_args += f"model={model1}"
-            logging.info(
-                f"Initializing {model1} model, with arguments: {simple_parse_args_string(model1_args)}"
-            )
-            lm1 = lm_tournament_eval.api.registry.get_model(model_type).create_from_arg_string(
-                model1_args,
-                {
-                    "batch_size": batch_size,
-                    "max_batch_size": max_batch_size,
-                    "device": device,
-                }
-            )
-    else:
-        if not isinstance(model1, lm_tournament_eval.api.model.LM):
-            raise TypeError
-        logging.info(f"Using pre-initialized model for model 1.")
-        lm1 = model1
-
-    # We don't currently support CachingLM
-
-    if task_manager is None:
-        task_manager = TaskManager(verbosity)
-
-    task_dict = get_task_dict(tasks, task_manager)
-    
-    # helper function to recursively apply config overrides to leaf subtasks, skipping their constituent groups.
-    # (setting of num_fewshot ; bypassing metric calculation ; setting fewshot seed)
-    def _adjust_config(task_dict):
-        adjusted_task_dict = {}
-        for task_name, task_obj in task_dict.items():
-            if isinstance(task_obj, dict):
-                adjusted_task_dict = {
-                    **adjusted_task_dict,
-                    **{task_name: _adjust_config(task_obj)},
-                }
-
-            else:
-                if task_obj.get_config("output_type") == "generate_until":
-                    if gen_kwargs is not None:
-                        task_obj.set_config(
-                            key="generation_kwargs", value=gen_kwargs, update=True
-                        )
-
-                if predict_only:
-                    eval_logger.info(
-                        f"Processing {task_name} in output-only mode. Metrics will not be calculated!"
-                    )
-                    # we have to change the class properties post-hoc. This is pretty hacky.
-                    task_obj.override_metric(metric_name="bypass")
-
-                # override tasks' fewshot values to the provided num_fewshot arg value
-                # except if tasks have it set to 0 manually in their configs--then we should never overwrite that
-                if num_fewshot is not None:
-                    if (default_num_fewshot := task_obj.get_config("num_fewshot")) == 0:
-                        eval_logger.info(
-                            f"num_fewshot has been set to 0 for {task_name} in its config. Manual configuration will be ignored."
-                        )
-                    else:
-                        eval_logger.warning(
-                            f"Overwriting default num_fewshot of {task_name} from {default_num_fewshot} to {num_fewshot}"
-                        )
-                        task_obj.set_config(key="num_fewshot", value=num_fewshot)
-                else:
-                    # if num_fewshot not provided, and the task does not define a default one, default to 0
-                    if (
-                        default_num_fewshot := task_obj.get_config("num_fewshot")
-                    ) is None:
-                        task_obj.set_config(key="num_fewshot", value=0)
-                # fewshot_random_seed set for tasks, even with a default num_fewshot (e.g. in the YAML file)
-                task_obj.set_fewshot_seed(seed=fewshot_random_seed)
-                eval_logger.info(
-                    f"Setting fewshot random generator seed to {fewshot_random_seed}"
-                )
-
-                adjusted_task_dict[task_name] = task_obj
-
-        return adjusted_task_dict
-
-    task_dict = _adjust_config(task_dict)
-
-    results0 = evaluate(
-        lm=lm0,
-        task_dict=task_dict,
-        limit=limit,
-    )
-
-    results1 = evaluate(
-        lm=lm1,
-        task_dict=task_dict,
-        limit=limit
-    )
-
-    # post-process results0 and results1
-    if lm0.rank == 0:
-        if isinstance(model0, str):
-            model0_name = model0
-        elif hasattr(model0, "config") and hasattr(model0.config, "_name_or_path"):
-            model0_name = model0.config._name_or_path
-        else:
-            model0_name = type(model0).__name__
-
-        results0["config"] = {
-            "model0": model0_name,
-            "model0_args": model0_args,
-        }
-
-        if isinstance(lm0, lm_tournament_eval.models.huggingface_model.HFLM):
-            results0["config"].update(lm0.get_model_info())
-
-        results0["config"].update(
-            {
-                "batch_size": batch_size,
-                "batch_sizes": (
-                    list(lm0.batch_sizes.values()) if hasattr(lm0, "batch_sizes") else []
-                ),
-                "device": device,
-                "use_cache": use_cache,
-                "limit": limit,
-                "bootstrap_iters": bootstrap_iters,
-                "gen_kwargs": gen_kwargs,
-                "random_seed": random_seed,
-                "numpy_seed": numpy_random_seed,
-                "torch_seed": torch_random_seed,
-                "fewshot_seed": fewshot_random_seed,
-            }
-        )
-
-        results0["git_hash"] = get_git_commit_hash()
-        results0["date"] = start_date
-        add_env_info(results0)  # additional environment info to results
-        add_tokenizer_info(results0, lm0)  # additional info about tokenizer
-    else:
-        return None
-
-    if lm1.rank == 0:
-        if isinstance(model1, str):
-            model1_name = model1
-        elif hasattr(model1, "config") and hasattr(model1.config, "_name_or_path"):
-            model1_name = model1.config._name_or_path
-        else:
-            model1_name = type(model1).__name__
-
-        results1["config"] = {
-            "model1": model1_name,
-            "model1_args": model1_args,
-        }
-
-        if isinstance(lm1, lm_tournament_eval.models.huggingface_model.HFLM):
-            results1["config"].update(lm1.get_model_info())
-
-        results1["config"].update(
-            {
-                "batch_size": batch_size,
-                "batch_sizes": (
-                    list(lm1.batch_sizes.values()) if hasattr(lm1, "batch_sizes") else []
-                ),
-                "device": device,
-                "use_cache": use_cache,
-                "limit": limit,
-                "bootstrap_iters": bootstrap_iters,
-                "gen_kwargs": gen_kwargs,
-                "random_seed": random_seed,
-                "numpy_seed": numpy_random_seed,
-                "torch_seed": torch_random_seed,
-                "fewshot_seed": fewshot_random_seed,
-            }
-        )
-
-        results1["git_hash"] = get_git_commit_hash()
-        results1["date"] = start_date
-        add_env_info(results1)  # additional environment info to results
-        add_tokenizer_info(results1, lm1)  # additional info about tokenizer
-    else:
-        return None
-    
-    return (results0, results1)
-
 def evaluate(
     lm: "LM",
-    task_dict,
+    requests,
+    eval_tasks,
     limit: Optional[int] = None,
     cache_requests: bool = False,
     rewrite_requests_cache: bool = False,
@@ -397,68 +82,25 @@ def evaluate(
         Dictionary of results
     """
 
-    #breakpoint()
-
     eval_logger.setLevel(getattr(logging, f"{verbosity}"))
 
-    # tracks all Instances/requests a model must generate output on.
-    requests = defaultdict(list)
-    # stores the amount to pad out reqs per req. type so that
-    # number of fwd passes per distributed rank is equal
-    padding_requests = defaultdict(int)
 
-    # get lists of group hierarchy and each type of request
-    eval_tasks = get_task_list(task_dict)
-    if not log_samples:
-        if not all(
-            "bypass" not in getattr(task_output.task, "_metric_fn_list", {}).keys()
-            for task_output in eval_tasks
-        ):
-            raise ValueError("log_samples must be True for 'bypass' metric-only tasks")
-    for task_output in eval_tasks:
-        task: Task = task_output.task
-        limit = get_sample_size(task, limit)
-        task.build_all_requests(
-            limit=limit,
-            rank=lm.rank,
-            world_size=lm.world_size,
-            cache_requests=cache_requests,
-            rewrite_requests_cache=rewrite_requests_cache,
-            system_instruction=system_instruction,
-            apply_chat_template=apply_chat_template,
-            fewshot_as_multiturn=fewshot_as_multiturn,
-            chat_template=getattr(lm, "apply_chat_template")
-            if apply_chat_template
-            else None,
-            tokenizer_name=getattr(lm, "tokenizer_name", "")
-            if apply_chat_template
-            else "",
-        )
-        eval_logger.debug(
-            f"Task: {task_output.task_name}; number of requests on this rank: {len(task.instances)}"
-        )
-        if write_out:
-            print_writeout(task)
-        # aggregate Instances by LM method requested to get output.
-        for instance in task.instances:
-            reqtype = instance.request_type
-            requests[reqtype].append(instance)
 
-        if lm.world_size > 1:
-            instances_rnk = torch.tensor(len(task._instances), device=lm.device)
-            gathered_item = (
-                lm.accelerator.gather(instances_rnk).cpu().detach().numpy().tolist()
-            )
-            # "multiple_choice" task types dispatch (several) "loglikelihood" request types
-            reqtype = (
-                "loglikelihood"
-                if task.OUTPUT_TYPE == "multiple_choice"
-                else task.OUTPUT_TYPE
-            )
-            # compute number of pseudo-batches to pad with (FSDP/DDP require even batches among ranks)
-            numpad = max(gathered_item) - gathered_item[lm.rank]
-            # todo: may not account for padding in cases like SquadV2 which has multiple req types
-            padding_requests[reqtype] += numpad
+    if lm.world_size > 1:
+        instances_rnk = torch.tensor(len(task._instances), device=lm.device)
+        gathered_item = (
+            lm.accelerator.gather(instances_rnk).cpu().detach().numpy().tolist()
+        )
+        # "multiple_choice" task types dispatch (several) "loglikelihood" request types
+        reqtype = (
+            "loglikelihood"
+            if task.OUTPUT_TYPE == "multiple_choice"
+            else task.OUTPUT_TYPE
+        )
+        # compute number of pseudo-batches to pad with (FSDP/DDP require even batches among ranks)
+        numpad = max(gathered_item) - gathered_item[lm.rank]
+        # todo: may not account for padding in cases like SquadV2 which has multiple req types
+        padding_requests[reqtype] += numpad
 
     ### Run LM on inputs, get all outputs ###
     # execute each type of request


### PR DESCRIPTION
this PR does a couple of things: 
- it creates an ELO object that works for both on and offline tournaments 
- it moves the `tournament_evaluate()` function into the tournament object
- separates out the model initialization into it's own function
- reduces redundant code in `tournament_evaluate()` (ie. calls it once per model) 


still todo: 
- [x] pass the model args to the initialization function
- [x] allow for matches to be done in the elo object
- [x] update elo per match
- [x] add match result back into elo object